### PR TITLE
Shield, Viewcones, and other stuff

### DIFF
--- a/Content.Shared/Blocking/BlockingSystem.Inky.cs
+++ b/Content.Shared/Blocking/BlockingSystem.Inky.cs
@@ -1,0 +1,20 @@
+using Content.Shared.Movement.Systems;
+
+namespace Content.Shared.Blocking;
+
+public sealed partial class BlockingSystem
+{
+    public void InitializeInky()
+    {
+        SubscribeLocalEvent<BlockingUserComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
+    }
+
+    public void OnRefreshMovespeed(EntityUid uid, BlockingUserComponent comp, RefreshMovementSpeedModifiersEvent args)
+    {
+        if (!_blockQuery.TryComp(comp.BlockingItem, out var blockingComp)
+            || !blockingComp.IsBlocking)
+            return;
+
+        args.ModifySpeed(comp.MovementModifier, comp.MovementModifier);
+    }
+}

--- a/Content.Shared/Blocking/BlockingSystem.Inky.cs
+++ b/Content.Shared/Blocking/BlockingSystem.Inky.cs
@@ -1,0 +1,20 @@
+using Content.Shared.Movement.Systems;
+
+namespace Content.Shared.Blocking;
+
+public sealed partial class BlockingSystem
+{
+    public void InitializeInky()
+    {
+        SubscribeLocalEvent<BlockingUserComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
+    }
+
+    public void OnRefreshMovespeed(EntityUid uid, BlockingUserComponent comp, RefreshMovementSpeedModifiersEvent args)
+    {
+        if (!_blockQuery.TryGetComponent(comp.BlockingItem, out var blockingComp)
+            || !blockingComp.IsBlocking)
+            return;
+
+        args.ModifySpeed(comp.MovementModifier, comp.MovementModifier);
+    }
+}

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -222,7 +222,7 @@ public sealed partial class BlockingSystem : EntitySystem
         Dirty(item, component);
 
         // inky start
-        TryComp(user, out MovementSpeedModifierComponent? moveMod);
+        if (TryComp(user, out MovementSpeedModifierComponent? moveMod))
             _movement.RefreshMovementSpeedModifiers(user, moveMod); // cursed? i might be retarded here but it works idk
         RaiseLocalEvent(user, new RefreshMovementSpeedModifiersEvent());
         // inky end
@@ -280,8 +280,8 @@ public sealed partial class BlockingSystem : EntitySystem
         Dirty(item, component);
 
         // inky start
-        TryComp(user, out MovementSpeedModifierComponent? moveMod);
-        _movement.RefreshMovementSpeedModifiers(user, moveMod);
+        if (TryComp(user, out MovementSpeedModifierComponent? moveMod))
+            _movement.RefreshMovementSpeedModifiers(user, moveMod);
         // inky end
 
         return true;

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -223,8 +223,10 @@ public sealed partial class BlockingSystem : EntitySystem
 
         // inky start
         if (TryComp(user, out MovementSpeedModifierComponent? moveMod))
+        {
             _movement.RefreshMovementSpeedModifiers(user, moveMod); // cursed? i might be retarded here but it works idk
-        RaiseLocalEvent(user, new RefreshMovementSpeedModifiersEvent());
+            RaiseLocalEvent(user, new RefreshMovementSpeedModifiersEvent());
+        }
         // inky end
 
         return true;

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -10,6 +10,8 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Item.ItemToggle;
 using Content.Shared.Maps;
 using Content.Shared.Mobs.Components;
+using Content.Shared.Movement.Components; // inky
+using Content.Shared.Movement.Systems; // inky
 using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.Toggleable;
@@ -42,10 +44,13 @@ public sealed partial class BlockingSystem : EntitySystem
     [Dependency] private EntityQuery<MobStateComponent> _mobQuery = default!;
     [Dependency] private EntityQuery<BlockingUserComponent> _userQuery = default!;
 
+    [Dependency] private MovementSpeedModifierSystem _movement = default!; // inky
+
     public override void Initialize()
     {
         base.Initialize();
         InitializeUser();
+        InitializeInky(); // inky
 
         SubscribeLocalEvent<BlockingComponent, GotEquippedHandEvent>(OnEquip);
         SubscribeLocalEvent<BlockingComponent, GotUnequippedHandEvent>(OnUnequip);
@@ -77,6 +82,10 @@ public sealed partial class BlockingSystem : EntitySystem
             var userComp = EnsureComp<BlockingUserComponent>(args.User);
             userComp.BlockingItem = uid;
             userComp.OriginalBodyType = physicsComponent.BodyType;
+
+            // inky start
+            userComp.MovementModifier = component.MovementModifier;
+            // inky end
         }
     }
 
@@ -187,12 +196,15 @@ public sealed partial class BlockingSystem : EntitySystem
         }
 
         //Don't allow someone to block if they're somehow not anchored.
+        /* inky start - new shields
         _transformSystem.AnchorEntity(user, xform);
         if (!xform.Anchored)
         {
             CantBlockError(user);
             return false;
         }
+        inky end */
+
         _actionsSystem.SetToggled(component.BlockingToggleActionEntity, true);
         _popupSystem.PopupPredicted(msgUser, msgOther, user, user);
 
@@ -208,6 +220,12 @@ public sealed partial class BlockingSystem : EntitySystem
 
         component.IsBlocking = true;
         Dirty(item, component);
+
+        // inky start
+        TryComp(user, out MovementSpeedModifierComponent? moveMod);
+            _movement.RefreshMovementSpeedModifiers(user, moveMod); // cursed? i might be retarded here but it works idk
+        RaiseLocalEvent(user, new RefreshMovementSpeedModifiersEvent());
+        // inky end
 
         return true;
     }
@@ -261,6 +279,11 @@ public sealed partial class BlockingSystem : EntitySystem
         component.IsBlocking = false;
         Dirty(item, component);
 
+        // inky start
+        TryComp(user, out MovementSpeedModifierComponent? moveMod);
+        _movement.RefreshMovementSpeedModifiers(user, moveMod);
+        // inky end
+
         return true;
     }
 
@@ -286,6 +309,11 @@ public sealed partial class BlockingSystem : EntitySystem
             if (HasComp<BlockingComponent>(shield) && _userQuery.TryGetComponent(user, out var blockingUserComponent))
             {
                 blockingUserComponent.BlockingItem = shield;
+
+                // inky start
+                RaiseLocalEvent(user, new RefreshMovementSpeedModifiersEvent());
+                // inky end
+
                 return;
             }
         }

--- a/Content.Shared/Blocking/Components/BlockingComponent.Inky.cs
+++ b/Content.Shared/Blocking/Components/BlockingComponent.Inky.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.Blocking;
+
+public sealed partial class BlockingComponent
+{
+    /// <summary>
+    /// The movement modifier that is applied when an entity raises the shield
+    /// </summary>
+    [DataField]
+    public float MovementModifier = 0.2f;
+}

--- a/Content.Shared/Blocking/Components/BlockingUserComponent.Inky.cs
+++ b/Content.Shared/Blocking/Components/BlockingUserComponent.Inky.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared.Blocking;
+
+public sealed partial class BlockingUserComponent
+{
+    [DataField]
+    public float MovementModifier = 1f;
+}

--- a/Resources/Prototypes/Entities/Clothing/Eyes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/misc.yml
@@ -28,8 +28,8 @@
 #    equipDelay: 3
 #    unequipDelay: 3
 #  - type: Blindfold
-  # /inky
   - type: EyeProtection
+    # /inky
   - type: Construction
     graph: Blindfold
     node: blindfold

--- a/Resources/Prototypes/Entities/Clothing/Eyes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/misc.yml
@@ -13,7 +13,9 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: entity
-  parent: ClothingEyesBase
+  parent:
+  - ClothingEyesBase
+  - BaseClothingViewconeBlinding # inky edit
   id: ClothingEyesBlindfold
   name: blindfold
   description: The bind leading the blind.
@@ -22,9 +24,12 @@
     sprite: Clothing/Eyes/Misc/blindfold.rsi
   - type: Clothing
     sprite: Clothing/Eyes/Misc/blindfold.rsi
-    equipDelay: 3
-    unequipDelay: 3
-  - type: Blindfold
+    # inky
+#    equipDelay: 3
+#    unequipDelay: 3
+#  - type: Blindfold
+  # /inky
+  - type: EyeProtection
   - type: Construction
     graph: Blindfold
     node: blindfold

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -25,7 +25,7 @@
   #    HeadSide : HEAD
 
 - type: entity
-  parent: [ ClothingHeadHelmetBase, BaseClothingViewconeMedium ] # Trauma - helmet reduces vision cone
+  parent: [ ClothingHeadHelmetBase ] # Trauma - helmet reduces vision cone // inky - removed BaseClothingViewconeMedium because WHAT THE FUCK BRO
   id: ClothingHeadHelmetArmoredBase
   abstract: true
   components:
@@ -444,7 +444,7 @@
 #ERT HELMETS
 #ERT Leader Helmet
 - type: entity
-  parent: [ BaseClothingViewconeSmall, BaseCentcommContraband, ClothingHeadHelmetArmoredBase, ClothingHeadHelmetBaseFoldable] # Trauma - less vision restriction, ClothingHeadHelmetBaseFoldable
+  parent: [ BaseCentcommContraband, ClothingHeadHelmetArmoredBase, ClothingHeadHelmetBaseFoldable] # Trauma - less vision restriction, ClothingHeadHelmetBaseFoldable // inky removed BaseClothingViewconeSmall
   id: ClothingHeadHelmetERTLeader
   name: ERT leader helmet
   description: An in-atmosphere helmet worn by the leader of a Nanotrasen Emergency Response Team. Has blue highlights.

--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -182,6 +182,7 @@
     sprite: Clothing/Shoes/Misc/snakeskin.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Misc/snakeskin.rsi
+  - type: NoSlip # inky - shush...
 
 - type: entity
   parent: [ClothingShoesBase, PowerCellSlotSmallItem, BaseToggleClothing]

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -50,7 +50,7 @@
               acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
-            damage: 50 # Trauma, was 100
+            damage: 120 # Trauma, was 100 // inky - fuck you let it be 120, what could go wrong
           behaviors:
             - !type:DoActsBehavior
               acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -208,4 +208,8 @@
     interfaces:
       enum.SelfRenamerUIKey.Key:
         type: SelfRenamerBoundUserInterface
+  - type: RadarBlip
+    scale: 5
+    shape: Ring
+    visibleFromOtherGrids: true
   # inky end

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
@@ -165,6 +165,11 @@
         type: SelfRenamerBoundUserInterface
   - type: MovementSpeedModifier # no lightning (ha get it) fast tesla
     baseSprintSpeed: 2.5
+  - type: RadarBlip
+    radarColor: cyan
+    scale: 5
+    shape: Ring
+    visibleFromOtherGrids: true
   # inky end
 
 - type: entity

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/other.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/other.yml
@@ -17,6 +17,9 @@
   objectType: Item
   theory:
     RevolutionaryKnowledge: 3
+  entityWhitelist: # inky edit - kill skills
+    components:
+    - Revolutionary
 
 - type: construction
   abstract: true

--- a/Resources/Prototypes/_Trauma/Store/categories.yml
+++ b/Resources/Prototypes/_Trauma/Store/categories.yml
@@ -21,3 +21,6 @@
   id: DiscountedItems
   name: store-discounted-items
   priority: 200
+  # inky
+  evil: true
+  # /inky

--- a/Resources/Textures/_Trauma/Shaders/viewcone.swsl
+++ b/Resources/Textures/_Trauma/Shaders/viewcone.swsl
@@ -17,7 +17,11 @@ uniform highp float ViewAngle;
 const highp float grainMult = 0.35;
 const highp float grainBase = 0.6;
 
-const highp float grayscaleFactor = 0.82;
+const highp float grayscaleFactor = 1.6; // inky (it makes shit more funny)
+
+// inky
+const highp float darkModif = 0.5;
+// /inky
 
 void fragment(){
     highp vec2 pixelSize = vec2(1.0/SCREEN_PIXEL_SIZE.x, 1.0/SCREEN_PIXEL_SIZE.y);
@@ -51,5 +55,9 @@ void fragment(){
     // Lil bit of grayscale for good measure, too
     highp float grayscale = zGrayscale(color.rgb) * (grain * grainMult + grainBase);
 
-    COLOR = vec4(mix(color.rgb, vec3(grayscale), mask * grayscaleFactor), color.a);
+    // inky start
+    vec3 darkNoise = vec3(grayscale) * darkModif;
+
+    COLOR = vec4(mix(color.rgb, darkNoise, mask * grayscaleFactor), color.a);
+    // /inky end
 }


### PR DESCRIPTION
Shields now slow you down by 80% when you raise them, instead of anchoring you to a tile.

Blindfolds and weldermasks now give viewcones, which are now generally darker

Teslas and singus now are seen on mass scanner

Sale uplink category is now red just as god intended (again)

Buffed shields to wizden values + slight buff

<img width="106" height="55" alt="image" src="https://github.com/user-attachments/assets/9ef73910-c62a-491e-af13-5652c17cb939" />
<img width="733" height="658" alt="image" src="https://github.com/user-attachments/assets/00eabfd3-1f80-4faa-a382-52f2694d5ad8" />
<img width="135" height="91" alt="image" src="https://github.com/user-attachments/assets/6ba7771a-fa40-447f-bb39-de5162100af5" />
