### PR TITLE
make calibers make more sense

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
@@ -8,7 +8,7 @@
     damage:
       types:
         Piercing: 18 # inky
-      armorPenetration: -0.25 # inky
+      armorPenetration: -0.2 # inky
 
 - type: entity
   parent: BaseBulletPractice

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -42,7 +42,7 @@
     damage:
       types:
         Piercing: 21 # inky
-      armorPenetration: 0.75 # Goobstation
+      armorPenetration: 0.8 # Goobstation
 
 - type: entity
   parent: [BaseBulletUranium, BaseBulletKinetic] # Trauma

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -8,6 +8,7 @@
     damage:
       types:
         Piercing: 14 # inky
+      armorPenetration: 0.2 # Trauma
 
 - type: entity
   parent: BaseBulletPractice
@@ -43,4 +44,4 @@
       types:
         # Radiation: 10 # Trauma, was 9 # inky
         Piercing: 11 # inky
-      armorPenetration: 0.5 # Trauma
+      armorPenetration: 0.6 # Trauma

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -207,7 +207,7 @@
   - type: ProjectileSpread
     proto: PelletShotgunUranium
     count: 6 # Trauma, was 5
-    spread: 6
+    spread: 15 # inky
 
 - type: entity
   parent: BaseBullet

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
@@ -13,7 +13,7 @@
     shape:
     - 0,0,1,1
   - type: PressureDamageChange
-    appliedModifier: 3.75
+    appliedModifier: 4 # inky
     applyToMelee: false
   - type: PressureEfficiency
   - type: UpgradeableWeapon

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Basic/pka.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Basic/pka.yml
@@ -6,8 +6,8 @@
   parent: [ BaseGunWieldable, WeaponProtoKineticAcceleratorBase, BaseCargoContraband ]
   description: Fires a spread of low-damage kinetic bolts that are half as effective for mining.
   components:
-  - type: PressureDamageChange
-    appliedModifier: 2.5
+  #- type: PressureDamageChange # inky
+  #  appliedModifier: 2.5
   - type: Sprite
     sprite: _Lavaland/Objects/Weapons/Guns/Basic/kinetic_shotgun.rsi
     layers:
@@ -76,8 +76,8 @@
   parent: [ WeaponProtoKineticAcceleratorBase, BaseCargoContraband ]
   description: Fires a barrage of medium-damage kinetic bolts at a short range.
   components:
-  - type: PressureDamageChange
-    appliedModifier: 3
+  #- type: PressureDamageChange # inky
+  #  appliedModifier: 3
   - type: Sprite
     sprite: _Lavaland/Objects/Weapons/Guns/Basic/kinetic_repeater.rsi
     layers:
@@ -107,8 +107,8 @@
   parent: [ WeaponProtoKineticAcceleratorBase, BaseCargoContraband ]
   description: Fires low-damage kinetic bolts, has a higher mod capacity.
   components:
-  - type: PressureDamageChange
-    appliedModifier: 3
+  #- type: PressureDamageChange # inky
+  #  appliedModifier: 3
   - type: Sprite
     sprite: _Lavaland/Objects/Weapons/Guns/Basic/kinetic_pistol.rsi
     layers:

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -20,8 +20,8 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 8
-        Structural: 11
+        Blunt: 10 # inky
+        Structural: 10 # inky
   # Short lifespan
   - type: TimedDespawn
     lifetime: 0.18 # roughly 4 tiles
@@ -63,7 +63,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 4
+        Blunt: 5 # inky
   - type: TimedDespawn
     lifetime: 0.22 # roughly 5.5 tiles
 
@@ -75,7 +75,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 4
+        Blunt: 2.5 # inky
 
 - type: entity
   id: PelletKinetic
@@ -92,8 +92,8 @@
   components:
   - type: ProjectileSpread
     proto: PelletKinetic
-    count: 4
-    spread: 20
+    count: 6 # inky
+    spread: 15 # inky
 
 - type: entity
   id: BulletCharge


### PR DESCRIPTION
massive nothingburger, just rounding some numbers so it all makes sense
all pkas now have their damage exactly 4x on lava instead of being random between 2.5-3.75x
all shotguns (including pka) now have exactly 15 degree spread (why tf does uranium ammo have 6 degree spread)
also added 0.15 (rounded to 0.2) ap to lecter, it was supposed to be there originally but i forgor