### PR TITLE
Fix inkymed shitcode

### DIFF
--- a/Content.Medical.Shared/Wounds/Systems/WoundSystem.Wounding.cs
+++ b/Content.Medical.Shared/Wounds/Systems/WoundSystem.Wounding.cs
@@ -200,7 +200,7 @@ public sealed partial class WoundSystem
             return;
 
         // Create or update wounds based on damage changes
-        foreach (var (damageType, damageValue) in args.ModifiedDamage.DamageDict) // inkymed - replaced args.Damage.DamageDict
+        foreach (var (damageType, damageValue) in args.Damage.DamageDict)
         {
             if (damageValue == 0)
                 continue; // Only create wounds for damage or healing
@@ -217,7 +217,7 @@ public sealed partial class WoundSystem
 
                 // inkymed - no more severity multiplier
                 TryInduceWound(uid,
-                    args.ModifiedDamage.GetWoundId(damageType), // inkymed - replaced args.Damage
+                    args.Damage.GetWoundId(damageType),
                     damageValue *
                     /*args.Damage.WoundSeverityMultipliers.GetValueOrDefault(damageType, 1)*/ 1,
                     out _,

--- a/Content.Shared/Mobs/Systems/MobThresholdSystem.Trauma.cs
+++ b/Content.Shared/Mobs/Systems/MobThresholdSystem.Trauma.cs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using Content.Medical.Common.Inkymed.Events; // inkymed
 using Content.Shared.Body;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
@@ -89,16 +88,11 @@ public sealed partial class MobThresholdSystem
         if (!_bodyQuery.HasComp(ent))
             return _damageable.GetTotalDamage(ent);
 
-        // inkymed
         var result = FixedPoint2.Zero;
         foreach (var part in _body.GetVitalParts(ent))
         {
-            var ev = new MobThresholdGetWoundableIntegrityEvent();
-            RaiseLocalEvent(part, ref ev);
-            if (ev.Handled)
-                result += ev.Damage;
+            result += _damageable.GetTotalDamage(part);
         }
-        // /inkymed
 
         return result;
     }


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
1) Revert some changes from - fb714ceccc70579f7a951ebc7f67c2818a808bcd
2) Revert some changes from - 194382f900496abe9561aa1aad7845de34e82f2c

## Technical details
<!-- Summary of code changes for easier review. -->
1) At some point, the damage on a body part in `WoundComponent` will be greater than in `DamageableComponent`, which makes it impossible to heal. This is connected to  `BleedInflicterComponent` attached to the damage type. I think `ModifiedDamage` isn't suitable here, that's it
2) The body part value threshold goes up only to 200. It's bad for the Goliath, for example, whose death threshold is 350 damage, but cuz he has only a torso he can only take up to 200 damage, after that he's immortal

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

### Before

https://github.com/user-attachments/assets/f30f336b-a614-4d4d-bded-7c50d0ae5610

### After

https://github.com/user-attachments/assets/d5a8d5dc-70e4-4029-a00d-9f375e2e1653

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [[Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html)](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- Fixed unhealable damage.
- Goliaths and other mobs with death thresholds over 200 are no longer immortal.